### PR TITLE
Accept base directory of ynikorn repos as cmd argument.

### DIFF
--- a/developer/yk-deploy.sh
+++ b/developer/yk-deploy.sh
@@ -7,7 +7,7 @@
 # The Docker registry where you want to push/pull images
 registry=gresearch
 # The base directory which contains all the Yunikorn repo dirs below
-yk_repos_base=$HOME/src/yunikorn
+yk_repos_base=${1:-$HOME/src/yunikorn}
 
 # Settings below here should not need to be changed
 


### PR DESCRIPTION
It seems convenient to take the `base_dir` as cmd arg, rather than manually modifying the `yk-deploy.sh` if the base directory is different.

