### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Description
This PR adds dependabot checks for go packages and github actions. No need to change settings of the repo. It will scan the repo immediately after merge. Scans can be seen in Insights > Dependency graph > Dependabot.

Fixes: https://github.com/G-Research/gr-oss/issues/722