### PR TITLE
Configure Zap logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .idea
 /coverage.txt
 /shellcheck
+temp

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /coverage.txt
 /shellcheck
 temp
+*.log

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/knadh/koanf/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
+	go.uber.org/zap v1.26.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (
@@ -30,7 +32,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/webservice/webservice.go
+++ b/internal/webservice/webservice.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/G-Research/yunikorn-history-server/log"
 
 	"github.com/G-Research/yunikorn-history-server/internal/config"
 	"github.com/G-Research/yunikorn-history-server/internal/repository"
@@ -65,7 +68,7 @@ func (ws *WebService) Start(ctx context.Context) {
 	})
 	ws.server.Handler = router
 	go func() {
-		fmt.Printf("Starting webservice on %s\n", ws.server.Addr)
+		log.Logger.Info(fmt.Sprintf("Starting webservice on %s", ws.server.Addr))
 		err := ws.server.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
 			fmt.Fprintf(os.Stderr, "HTTP serving error: %v\n", err)

--- a/internal/ykclient/client.go
+++ b/internal/ykclient/client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/G-Research/yunikorn-history-server/log"
+
 	"github.com/google/uuid"
 
 	"github.com/G-Research/yunikorn-history-server/internal/config"
@@ -47,7 +49,7 @@ func (c *Client) Run(ctx context.Context) {
 	}
 
 	go func() {
-		fmt.Println("Starting YuniKorn event stream client")
+		log.Logger.Info("Starting YuniKorn event stream client")
 		c.FetchEventStream(ctx, streamURL, evCounts)
 	}()
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,56 @@
+package log
+
+import (
+	"os"
+	"sync"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// TODO: implement a mechanism to load this values from configuration
+const (
+	logFilePath = "temp/logs/yhs.log"
+	maxSize     = 5
+	maxBackups  = 10
+	maxAge      = 14
+	compress    = true
+	logLevel    = zap.InfoLevel
+)
+
+var (
+	once   sync.Once
+	Logger *zap.Logger
+)
+
+func init() {
+	once.Do(func() {
+		stdout := zapcore.AddSync(os.Stdout)
+		file := zapcore.AddSync(&lumberjack.Logger{
+			Filename:   logFilePath,
+			MaxSize:    maxSize,
+			MaxBackups: maxBackups,
+			MaxAge:     maxAge,
+			Compress:   compress,
+		})
+
+		productionCfg := zap.NewProductionEncoderConfig()
+		productionCfg.TimeKey = "timestamp"
+		productionCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+
+		developmentCfg := zap.NewDevelopmentEncoderConfig()
+		developmentCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+
+		consoleEncoder := zapcore.NewConsoleEncoder(developmentCfg)
+		fileEncoder := zapcore.NewJSONEncoder(productionCfg)
+
+		core := zapcore.NewTee(
+			zapcore.NewCore(consoleEncoder, stdout, logLevel),
+			zapcore.NewCore(fileEncoder, file, logLevel),
+		)
+
+		Logger = zap.New(core)
+	})
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -12,7 +12,7 @@ import (
 
 // TODO: implement a mechanism to load this values from configuration
 const (
-	logFilePath = "temp/logs/yhs.log"
+	logFilePath = "yhs.log"
 	maxSize     = 5
 	maxBackups  = 10
 	maxAge      = 14


### PR DESCRIPTION
I reviewed the implementation of `zap` in the `ynikorn-core` repository. In this PR, I've included a trimmed-down version based on their approach. I would greatly appreciate your feedback to determine if this is something we can proceed with. 

Logs are saved into a file as well as into standard out.
**Tasks** 
- [x] Configure log package
- [x] Some sample refactor of the current print statements

**Output**

<img width="634" alt="image" src="https://github.com/G-Research/yunikorn-history-server/assets/32765701/966c18e8-3bfc-4588-9157-0e4e7460b0dc">
