### PR TITLE
make pipeline fail on linting errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           key: golangci-lint-${{ steps.golangci-lint-cache-info.outputs.version }}-go-${{ steps.setup-go.outputs.go-version }}-mod-${{ hashFiles('go.sum') }}
 
       - name: Run golangci-lint
-        run: make go-lint
+        run: make go-lint || exit 1
 
   build:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id


### PR DESCRIPTION
Currently, the pipeline does not fail even if there are linting errors. As a result, it displays "All checks passed" despite the presence of these errors. 
Another issue is that we currently only have a `lint` job. However, I anticipate that we will eventually add `build` and `deploy` jobs as well. In fact, there is an open PR for the build job 🙂  
So, It makes sense to stop the pipeline if there are potential errors in the testing stage.

The screenshot shows `All check passed` even though we have linting errors.
<img width="927" alt="image" src="https://github.com/G-Research/yunikorn-history-server/assets/32765701/8cfd0464-0015-4130-82a4-896b7b4f406c">
