### PR TITLE
Removes the copying of `yhs.yml` from the Dockerfile #32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.19
 
-COPY yhs.yml .
 COPY build/event-collector /usr/local/bin/
 
 ENTRYPOINT ["event-collector"]


### PR DESCRIPTION
closes #32 