### PR TITLE
Add check-required workflow and release workflow

### DIFF
--- a/.github/workflows/check-required.yml
+++ b/.github/workflows/check-required.yml
@@ -1,0 +1,97 @@
+name: Check required jobs
+
+# This workflow is triggered when a workflow run for the CI is completed.
+# It checks if the "All required checks done" job was actually successful
+# (and not just skipped) and creates a check run if that is the case. The
+# check run can be used to protect the main branch from being merged if the
+# CI is not passing. We need to use a GitHub app token to create the check
+# run because otherwise the check suite will be assigned to the first workflow
+# run for the CI, which might not be the latest one. See
+# https://github.com/orgs/community/discussions/24616#discussioncomment-6088422
+# for more details.
+
+on:
+  workflow_run:
+    workflows: [CI]
+
+permissions:
+  actions: read
+  checks: write
+
+jobs:
+  required-jobs:
+    name: Check required jobs
+    if: ${{ !github.event.repository.fork }}
+    environment: create-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate an app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const ghaAppId = 15368;
+            const ghaName = 'All required checks done';
+            const myAppId = ${{ secrets.APP_ID }};
+            const myName = 'All required checks succeeded';
+            const owner = context.payload.repository.owner.login;
+            const repo = context.payload.repository.name;
+            const sha = context.payload.workflow_run.head_sha;
+
+            core.info(`List GitHub Actions check runs for ${sha}.`)
+            const { data: { check_runs: ghaChecks } } = await github.rest.checks.listForRef({
+              owner: owner,
+              repo: repo,
+              ref: sha,
+              app_id: ghaAppId,
+              check_name: ghaName,
+            });
+
+            var newCheck = {
+              owner: owner,
+              repo: repo,
+              name: myName,
+              head_sha: sha,
+              status: 'in_progress',
+              started_at: context.payload.workflow_run.created_at,
+              output: {
+                title: 'Not all required checks succeeded',
+              },
+            };
+
+            core.summary.addHeading('The following required checks have been considered:', 3);
+            ghaChecks.forEach(check => {
+              core.summary
+                .addLink(check.name, check.html_url)
+                .addCodeBlock(JSON.stringify(check, ['status', 'conclusion', 'started_at', 'completed_at'], 2), 'json');
+
+              if (check.status === 'completed' && check.conclusion === 'success') {
+                newCheck.status = 'completed';
+                newCheck.conclusion = 'success';
+                newCheck.started_at = check.started_at;
+                newCheck.completed_at = check.completed_at;
+                newCheck.output.title = 'All required checks succeeded';
+              } else if (check.started_at > newCheck.started_at) {
+                newCheck.started_at = check.started_at;
+              }
+            });
+            if (ghaChecks.length === 0) {
+              core.summary.addRaw(`No check runs for ${sha} found.`);
+            }
+            newCheck.output.summary = core.summary.stringify();
+            await core.summary.write();
+
+            core.info(`Create own check run for ${sha}: ${JSON.stringify(newCheck, null, 2)}.`)
+            const { data: { html_url } } = await github.rest.checks.create(newCheck);
+
+            await core.summary
+              .addHeading('Check run created:', 3)
+              .addLink(myName, html_url)
+              .addCodeBlock(JSON.stringify(newCheck, null, 2), 'json')
+              .write();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,26 @@ jobs:
         with:
           name: yunikorn-history-server-oci-images-${{ matrix.arch }}
           path: yunikorn-history-server-oci-*.tar
+  # Virtual job that can be configured as a required check before a PR can be merged.
+  # As GitHub considers a check as successful if it is skipped, we need to check its status in
+  # another workflow (check-required.yml) and create a check there.
+  all-required-checks-done:
+    name: All required checks done
+    needs:
+      - go-lint
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All required checks done"
+
+  release:
+    name: Release
+    needs: all-required-checks-done
+    if: ${{ !github.event.repository.fork && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
+    permissions:
+      actions: write
+      contents: write
+      pages: write
+      id-token: write
+    secrets: inherit
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-release:
+    name: Publish container image to DockerHub
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      # We need to checkout the repo in order to determine the latest tag.
+      - name: Checkout
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: 1
+
+      # The main branch is tagged as "main" and "edge".
+      # Tags are named after the version, e.g. "v0.1.0" -> "0.1.0".
+      # The latest non-prerelease version is also tagged as "latest".
+      # This is achieved by sorting the tags by version number, then filtering
+      # out prereleases and taking the last tag.
+      - name: Compute tags
+        id: tags
+        run: |
+          ref='${{ github.ref }}'
+          case $ref in
+            refs/heads/main)
+              tags=("main" "edge")
+              ;;
+            refs/tags/v*)
+              tags=("${ref#refs/tags/v}")
+              if [ "$(git -c 'versionsort.suffix=-' for-each-ref --sort=version:refname --format='%(refname)' 'refs/tags/v*' | grep -v -- - | tail -n1)" == "$ref" ]; then
+                tags+=("latest")
+              fi
+          esac
+          echo "ref=${ref#refs/*/}" >> $GITHUB_OUTPUT
+          echo "tags=${tags[@]}" >> $GITHUB_OUTPUT
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: yunikorn-history-server-oci-images-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub
+        run: |
+          tags=(${{ steps.tags.outputs.tags }})
+          for image in yunikorn-history-server-oci-*.tar
+          do
+            digest=$(tar -xOf $image index.json | jq -r '.manifests[0].digest')
+            digests+=($digest)
+            echo "::group::Pushing $image to ${{ vars.DOCKER_REPO }}@$digest"
+            skopeo copy oci-archive:$image:${{ steps.tags.outputs.ref }} docker://${{ vars.DOCKER_REPO }}@$digest
+            echo "::endgroup::"
+          done
+          echo "::group::Pushing merged manifest to ${{ vars.DOCKER_REPO }} for tags: ${tags[@]}"
+          docker buildx imagetools create \
+            $(printf -- "--tag ${{ vars.DOCKER_REPO }}:%s " ${tags[@]}) \
+            $(printf "${{ vars.DOCKER_REPO }}@%s " ${digests[@]})
+          echo "::endgroup::"


### PR DESCRIPTION
# Description
This PR adds workflows for releasing built docker images for YHS, and a `check-required` workflow as in FML. There are a couple of prerequisites before merging this PR.

Prerequisites:
- [x] create and install a new GitHub app with the `check:write` permissions
- [x] add its credentials to a new `create-check` environment that can only be accessed by the `main` branch. Credentials are found in app settings. Look for app id, and create a private key for the app.
  - [x] secrets should be named `APP_ID` and `APP_PRIVATE_KEY` and placed in the environment
- [x] Create one more environment called `release` also accessed by the `main` branch
  - [x] add two secrets `DOCKER_PASSWORD` and `DOCKER_USERNAME`. Docker password should be a PAT generated in Docker hub. add an environment variable called `DOCKER_REPO` in format `<docker account>/<docker repository`>`

Fixes: https://github.com/G-Research/gr-oss/issues/729