### PR TITLE
Performance testing using k6 for event handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,6 @@ test-go-e2e: gotestsum ## run go e2e tests.
 	$(GOTESTSUM) $(TEST_ARGS) ./test/e2e/... -run E2E
 
 test-k6-performance: ## run k6 performance tests.
-	mkdir -p test-reports/performance
 	touch test-reports/performance/report.json
 	$(K6) run -e NAMESPACE=$(NAMESPACE) test/performance/*_test.js --out json=test-reports/performance/report.json
 
@@ -369,7 +368,7 @@ K6_VERSION ?= v0.52.0
 .PHONY: xk6
 xk6: $(XK6) ## Download xk6 locally if necessary.
 $(XK6): bin/tooling
-	test -s $(XK6) || GOBIN=$(LOCALBIN_TOOLING) go install go.k6.io/xk6/cmd/xk6@latest
+	test -s $(XK6) || GOBIN=$(LOCALBIN_TOOLING) $(GO) install go.k6.io/xk6/cmd/xk6@latest
 
 .PHONY: k6
 k6: xk6 $(K6) ## Download k6 locally if necessary.

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -3,36 +3,73 @@
 set -e
 
 TEST_TYPE=$1
-if [ "$TEST_TYPE" != "integration" ] && [ "$TEST_TYPE" != "e2e" ]; then
-    echo "Invalid test type: $TEST_TYPE. Please provide either 'integration' or 'e2e' as the first argument."
+if [ "$TEST_TYPE" != "integration" ] && [ "$TEST_TYPE" != "e2e" ] && [ "$TEST_TYPE" != "performance" ]; then
+    echo "Invalid test type: $TEST_TYPE. Please provide either 'integration', 'e2e' or 'performance' as the first argument."
     exit 1
 fi
 
-# Cleanup the kind cluster when the script exits
+YHS_SERVER=$(YHS_SERVER:-http://localhost:8989}
+
+# Cleanup the kind cluster and yunikorn-history-server process when the script exits
 cleanup () {
     echo "**********************************"
     echo "Deleting kind cluster"
     echo "**********************************"
-    KIND_CLUSTER=yhs-integration-tests make kind-delete-cluster
+    KIND_CLUSTER=yhs-test make kind-delete-cluster
+
+    if [ "$TEST_TYPE" == "performance" ]; then
+        echo "**********************************"
+        echo "Terminating yunikorn-history-server"
+        echo "**********************************"
+        pkill -f yunikorn-history-server
+    fi
 }
 trap cleanup EXIT
+
+wait_for_yhs() {
+    echo "**********************************"
+    echo "Waiting for yunikorn history server to start"
+    echo "**********************************"
+    while true; do
+        echo "Sending request to yunikorn history server..."
+        url="$YHS_SERVER/ws/v1/health/readiness"
+        status_code=$(curl --write-out %{http_code} --silent --output /dev/null $url || true)
+
+        if [ "$status_code" -eq 200 ] ; then
+            echo "Yunikorn history server is up and running."
+            break
+        else
+            echo "Waiting for yunikorn history server to start..."
+            sleep 10
+        fi
+    done
+}
 
 echo "**********************************"
 echo "Creating kind cluster"
 echo "**********************************"
-KIND_CLUSTER=yhs-integration-tests make kind-create-cluster
+KIND_CLUSTER=yhs-test make kind-create-cluster
 
 echo "**********************************"
 echo "Install and configure dependencies"
 echo "**********************************"
-make install-dependencies
+make install-dependencies migrate-up
 
-echo "**********************************"
-echo "Apply database migrations"
-echo "**********************************"
-make migrate-up
+if [ "$TEST_TYPE" == "performance" ]; then
+    echo "**********************************"
+    echo "Run yunikorn history server"
+    make clean build
+    make run &
+
+    # Wait for yunikorn history server to start
+    wait_for_yhs
+fi
 
 echo "**********************************"
 echo "Running $TEST_TYPE tests"
 echo "**********************************"
-make "test-go-$TEST_TYPE"
+if [ "$TEST_TYPE" == "performance" ]; then
+    make "test-k6-$TEST_TYPE"
+else
+    make "test-go-$TEST_TYPE"
+fi

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -8,7 +8,7 @@ if [ "$TEST_TYPE" != "integration" ] && [ "$TEST_TYPE" != "e2e" ] && [ "$TEST_TY
     exit 1
 fi
 
-YHS_SERVER=$(YHS_SERVER:-http://localhost:8989}
+YHS_SERVER=${YHS_SERVER:-http://localhost:8989}
 
 # Cleanup the kind cluster and yunikorn-history-server process when the script exits
 cleanup () {
@@ -58,8 +58,9 @@ make install-dependencies migrate-up
 if [ "$TEST_TYPE" == "performance" ]; then
     echo "**********************************"
     echo "Run yunikorn history server"
+    mkdir -p test-reports/performance
     make clean build
-    make run &
+    bin/app/yunikorn-history-server --config config/yunikorn-history-server/local.yml > test-reports/performance/yhs.log &
 
     # Wait for yunikorn history server to start
     wait_for_yhs

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,0 +1,22 @@
+# Performance Tests using k6
+K6 is an open-source load testing tool for testing the performance of your backend infrastructure. `xk6` is a tool that makes easy to 
+interact with kubernetes while writing load tests using `k6.` In this setup we use `k6` with `xk6` extension to test the performance of 
+different components of the Yunikorn History Server.
+
+## Prerequisites
+- [K6](https://grafana.com/docs/k6/latest/)
+- [xk6 Extension](https://github.com/grafana/xk6-kubernetes?tab=readme-ov-file)
+
+## Available tests
+
+- [Event HandlerTest](`event_handler_test.js`) : When an event is generated in the cluster `event_handler` listen to the event and store 
+it in the database. This test is used to test the
+performance of the event handler when multiple events are generated in the cluster.
+
+## Running the Tests
+
+1. Run the tests using the `performance-tests` target in the Makefile.
+
+```bash
+make performance-tests
+```

--- a/test/performance/event_handler_test.js
+++ b/test/performance/event_handler_test.js
@@ -1,0 +1,58 @@
+import { Kubernetes } from 'k6/x/kubernetes';
+import http from 'k6/http';
+import { Trend } from 'k6/metrics';
+
+let podsSubmitted = new Trend('pods_submitted');
+let eventsProcessed = new Trend('events_processed');
+
+const namespace = __ENV.NAMESPACE || 'default';
+const yhsServer = __ENV.YHS_SERVER || 'http://localhost:8989';
+
+const podTemplate = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+        generateName: 'test-pod-',
+        labels: {
+            app: 'performance-by-k6'
+        },
+        namespace: namespace
+    },
+    spec: {
+        containers: [
+            {
+                name: 'test-container',
+                image: 'nginx:latest',
+                ports: [{ containerPort: 80 }]
+            }
+        ]
+    }
+};
+
+export const options = {
+    stages: [
+        { duration: '5s', target: 5 },
+        { duration: '5s', target: 5 },
+        { duration: '5s', target: 0 },
+    ],
+};
+
+const getStat = () => {
+    const res = http.get(`${yhsServer}/ws/v1/event-statistics`);
+    return JSON.parse(res.body);
+};
+
+export default function () {
+    const kubernetes = new Kubernetes();
+    try {
+        kubernetes.create(podTemplate);
+    } catch (error) {
+        console.log(`Failed to create pod: ${error}`);
+    }
+    const json = getStat();
+    const eventProcessedByYHS = json["APP-ADD"]
+    const pods = kubernetes.list("Pod", namespace);
+    // Add the number of pods submitted and the number of events processed to the metrics
+    podsSubmitted.add(pods.length);
+    eventsProcessed.add(eventProcessedByYHS);
+}


### PR DESCRIPTION
Related to #34
A load test was done on the cluster using [K6](https://grafana.com/docs/k6/latest/). A variable number of `VUs` are used to create a burst of events in the cluster. 

The number of `APP.ADD` events captured by YHS is counted.

### Tests 1: 
Time: **15s, 5 virtual users (VUs)** for concurrent submission of pods in the cluster
Pod Submitted: 450
Event processed by YHS: 550

### Tests 2: 
Time: **15s, 10 virtual users (VUs)** for concurrent submission of pods in the cluster
Pod Submitted: 690
Event processed by YHS: 790

### Tests 3: 
Time: **15s, 10 virtual users (VUs)** for concurrent submission of pods in the cluster
Pod Submitted: 909
Event processed by YHS: 909

### Tests 4: 
Time: **25s, 50 virtual users (VUs)** for concurrent submission of pods in the cluster
Pod Submitted: 4008
Event processed by YHS: 4108

<img width="1431" alt="image" src="https://github.com/G-Research/yunikorn-history-server/assets/32765701/91a3ddc0-e5d9-420f-8d22-804c4cc02464">


