### PR TITLE
Add tests job and fail job if lint errors found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,22 @@ jobs:
       - name: Run golangci-lint
         run: make go-lint
 
+  go-unit-tests:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+    name: Go Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          cache-prefix: go-unit-tests
+
+      - name: Run Go Unit Tests
+        run: make test-go-unit
+
   build:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Build (${{ matrix.os }}/${{ matrix.arch }})
@@ -139,6 +155,7 @@ jobs:
     name: All required checks done
     needs:
       - go-lint
+      - go-unit-tests
       - build
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clean:
 .PHONY: go-lint
 go-lint: ## run go linters.
 	@echo '>>> Running go linters.'
-	@golangci-lint run -v --issues-exit-code 0 ## TODO: remove after fixing all lint issues
+	@golangci-lint run -v
 
 .PHONY: install-tools
 install-tools: ## install tools.


### PR DESCRIPTION
# Description
This PR adds a job that runs go unit tests. Also, a linter flag that ignores lint errors is removed so now the job and workflow will fail if lint errors are found.

Working examples:
- [No lint errors all good and green](https://github.com/gr-oss-devops/yunikorn-history-server/actions/runs/9463353428)
- [Some lint errors, job failed](https://github.com/gr-oss-devops/yunikorn-history-server/actions/runs/9463494677/job/26068801697)

Fixes: https://github.com/G-Research/gr-oss/issues/733