### PR TITLE
Add support for using minikube as K8S base, update README.

### DIFF
--- a/developer/README.md
+++ b/developer/README.md
@@ -8,7 +8,32 @@ of the Yunikorn History Server (YHS).
 - README.md - this file
 - docker-compose.yml - a Docker Compose file for running infrastructure services for YHS
 - postgres-init.sh - a script to create the basic entities for the YHS database
-- yk-deploy.sh - a script to start a Kind (K8S) cluster with the Yunikorn Scheduler
+- yk-deploy.sh - a script to start a K8S cluster with the Yunikorn Scheduler
+
+## Required Tools/Packages
+
+You will need several software packages installed to develop and test YHS. The necessary
+packages, and how to install them are:
+
+- Docker Desktop - packages can be downloaded from https://www.docker.com/products/docker-desktop/
+After installation, you should be able to run `docker ps` and it should show no containers running.
+
+- The Go compiler and toolset - this can be installed from tar archives from https://go.dev - they
+offer packages for Windows, macOS, and Linux. Note that if you are running macOS, you can install
+Go using the Brew package manager (`brew install go`). On Linux systems, you may be able to
+install using `apt` or `dnf` (e.g. `sudo apt install golang`), but note that some Linux distributions
+ship fairly old versions of Go.
+
+- Either `kind` ("Kubernetes on Docker") or `minikube` to run a K8S cluster on Docker; see documentation for
+`kind` at https://kind.sigs.k8s.io and `minikube` at https://minikube.sigs.k8s.io.
+Usually the easiest way to install `kind` is by using `go install` directly to download and build
+the binary: `go install sigs.k8s.io/kind@v0.23.0`. To install `minikube`, follow the download
+instructions at https://minikube.sigs.k8s.io.
+
+- The `curl` and `jq` utilities are very useful for fetching and formatting response data from Yunikorn
+and YHS servers, to do quick manual checks. They are often available via package managers on your system,
+or can be downloaded directly from https://curl.se/ and https://github.com/jqlang/jq, respectively.
+
 
 ## Repository setup for developing and running Yunikorn and YHS
 
@@ -39,8 +64,11 @@ yunikorn-history-server/      yunikorn-scheduler-interface/
 
 ## Running Yunikorn and YHS
 
-- Start a K8S (`kind`) cluster, with Yunikorn. Change into the `yunikorn-history-server/developer` directory
-and run:
+- Start a K8S cluster, with Yunikorn. Change into the `yunikorn-history-server/developer` directory.
+It will use `kind` to deploy a K8S cluster on Docker, but if you prefer `minikube`, edit the `yk-deploy.sh`
+file, and change the `k8s_mgr` variable setting to `minikube`.
+
+Then run:
 ```sh
   $ ./yk-deploy.sh
 ``` 


### PR DESCRIPTION
As some developers in the SPARK team at G-R are using `minikube` to do Yunikorn development and testing, this PR adds support for using `minikube` in lieu of `kind` for running YHS. Also, some more info about tool requirements has been added to the `developer/README.md`.

Fixes https://github.com/G-Research/yunikorn-history-server/issues/47