### PR TITLE
Consistently process env vars and config parameter from yhs

### DIFF
--- a/cmd/event-collector/main_test.go
+++ b/cmd/event-collector/main_test.go
@@ -53,16 +53,12 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Setenv("YHS_YUNIKORN_HOST", "localhost")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.Setenv("YHS_YUNIKORN_PORT", "8080")
+	err = os.Setenv("YHS_DB_POOL_MAX_CONN_IDLE_TIME", "120s")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Load with empty config file
+	// Load with empty config file, should ignore and default to env vars
 	configFile := "this_file_does_not_exist.yaml"
 	k, err := loadConfig(configFile)
 	if err != nil {
@@ -70,6 +66,5 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	}
 
 	assert.Equal(t, "http", k.String("yunikorn.protocol"))
-	assert.Equal(t, "localhost", k.String("yunikorn.host"))
-	assert.Equal(t, 8080, k.Int("yunikorn.port"))
+	assert.Equal(t, "120s", k.String("db.pool_max_conn_idle_time"))
 }

--- a/yhs.yml
+++ b/yhs.yml
@@ -14,4 +14,4 @@ db:
   pool_max_conn_lifetime: 1800s
   pool_max_conn_idle_time: 120s
 yhs:
-  serverAddr: ":8989"
+  server_addr: ":8989"


### PR DESCRIPTION
Closes #45 #46

Changes:

- [x] Update logic of `loadConfig()`
- [x] Make all configuration parameter definitions consistent
- [x] Bugfix: improper read of env parameters #45
- [x] Update unit tests