### PR TITLE
Configuration support for zap logger

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -23,6 +23,12 @@ A Helm charts for Yunikorn History Server (YHS)
 | image.registry | string | `"docker.io"` | Docker registry |
 | image.repository | string | `"gresearch/yunikorn-history-server"` | Docker image repository |
 | image.tag | string | `"latest"` | Docker image tag |
+| log.compress | bool | `true` | Compress log files |
+| log.filePath | string | `"yhs.log"` | Log file path |
+| log.level | string | `"INFO"` | Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL |
+| log.maxAge | int | `30` | Maximum age of log files in days |
+| log.maxBackups | int | `10` | Maximum number of log file backups |
+| log.maxSize | int | `5` | Maximum log file size in megabytes |
 | replicaCount | int | `1` | Number of replicas for the deployment |
 | service.port | int | `8989` | Service port |
 | service.targetPort | int | `8989` | Service target port |

--- a/charts/README.md
+++ b/charts/README.md
@@ -23,8 +23,8 @@ A Helm charts for Yunikorn History Server (YHS)
 | image.registry | string | `"docker.io"` | Docker registry |
 | image.repository | string | `"gresearch/yunikorn-history-server"` | Docker image repository |
 | image.tag | string | `"latest"` | Docker image tag |
+| log.jsonFormat | bool | `true` | Output type of the log, if true, log will be output in json format |
 | log.level | string | `"INFO"` | Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL |
-| log.useJSONFormat | bool | `true` | Output type of the log, if true, log will be output in json format |
 | replicaCount | int | `1` | Number of replicas for the deployment |
 | service.port | int | `8989` | Service port |
 | service.targetPort | int | `8989` | Service target port |

--- a/charts/README.md
+++ b/charts/README.md
@@ -23,12 +23,8 @@ A Helm charts for Yunikorn History Server (YHS)
 | image.registry | string | `"docker.io"` | Docker registry |
 | image.repository | string | `"gresearch/yunikorn-history-server"` | Docker image repository |
 | image.tag | string | `"latest"` | Docker image tag |
-| log.compress | bool | `true` | Compress log files |
-| log.filePath | string | `"yhs.log"` | Log file path |
 | log.level | string | `"INFO"` | Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL |
-| log.maxAge | int | `30` | Maximum age of log files in days |
-| log.maxBackups | int | `10` | Maximum number of log file backups |
-| log.maxSize | int | `5` | Maximum log file size in megabytes |
+| log.production | bool | `true` | Output type of the log, if true, log will be output in json format |
 | replicaCount | int | `1` | Number of replicas for the deployment |
 | service.port | int | `8989` | Service port |
 | service.targetPort | int | `8989` | Service target port |

--- a/charts/README.md
+++ b/charts/README.md
@@ -24,7 +24,7 @@ A Helm charts for Yunikorn History Server (YHS)
 | image.repository | string | `"gresearch/yunikorn-history-server"` | Docker image repository |
 | image.tag | string | `"latest"` | Docker image tag |
 | log.level | string | `"INFO"` | Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL |
-| log.production | bool | `true` | Output type of the log, if true, log will be output in json format |
+| log.useJSONFormat | bool | `true` | Output type of the log, if true, log will be output in json format |
 | replicaCount | int | `1` | Number of replicas for the deployment |
 | service.port | int | `8989` | Service port |
 | service.targetPort | int | `8989` | Service target port |

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -10,7 +10,7 @@
 {{- $dbPoolMaxConnLifetime := .Values.db.poolMaxConnLifetime | required "A valid .db.poolMaxConnLifetime is required!" -}}
 {{- $dbPoolMaxConnIdleTime := .Values.db.poolMaxConnIdleTime | required "A valid .db.poolMaxConnIdleTime is required!" -}}
 {{- $yhsServerAddr := .Values.yhsServerAddr | required "A valid .yhsServerAddr is required!" -}}
-{{- $logProduction := .Values.log.production | required "A valid .log.production is required!" -}}
+{{- $logJSONFormat := .Values.log.useJSONFormat | required "A valid .log.useJSONFormat is required!" -}}
 {{- $logLevel := .Values.log.level | required "A valid .log.level is required!" -}}
 
 
@@ -37,5 +37,5 @@ data:
   YHS_DB_POOL_MAX_CONN_LIFETIME: "{{ $dbPoolMaxConnLifetime }}"
   YHS_DB_POOL_MAX_CONN_IDLE_TIME: "{{ $dbPoolMaxConnIdleTime }}"
   YHS_YHS_SERVER_ADDR: "{{ $yhsServerAddr }}"
-  YHS_LOG_PRODUCTION: "{{ $logProduction }}"
+  YHS_LOG_USE_JSON_FORMAT: "{{ $logJSONFormat }}"
   YHS_LOG_LEVEL: "{{ $logLevel }}"

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -10,6 +10,14 @@
 {{- $dbPoolMaxConnLifetime := .Values.db.poolMaxConnLifetime | required "A valid .db.poolMaxConnLifetime is required!" -}}
 {{- $dbPoolMaxConnIdleTime := .Values.db.poolMaxConnIdleTime | required "A valid .db.poolMaxConnIdleTime is required!" -}}
 {{- $yhsServerAddr := .Values.yhsServerAddr | required "A valid .yhsServerAddr is required!" -}}
+{{- $logFilePath := .Values.log.filePath | required "A valid .log.filePath is required!" -}}
+{{- $logMaxSize := .Values.log.maxSize | required "A valid .log.maxSize is required!" -}}
+{{- $logMaxBackups := .Values.log.maxBackups | required "A valid .log.maxBackups is required!" -}}
+{{- $logMaxAge := .Values.log.maxAge | required "A valid .log.maxAge is required!" -}}
+{{- $logCompress := .Values.log.compress | required "A valid .log.compress is required!" -}}
+{{- $logLevel := .Values.log.level | required "A valid .log.level is required!" -}}
+
+
 
 apiVersion: v1
 kind: ConfigMap
@@ -33,3 +41,9 @@ data:
   YHS_DB_POOL_MAX_CONN_LIFETIME: "{{ $dbPoolMaxConnLifetime }}"
   YHS_DB_POOL_MAX_CONN_IDLE_TIME: "{{ $dbPoolMaxConnIdleTime }}"
   YHS_YHS_SERVER_ADDR: "{{ $yhsServerAddr }}"
+  LOG_FILE_PATH: "{{ $logFilePath }}"
+  LOG_MAX_SIZE: "{{ $logMaxSize }}"
+  LOG_MAX_BACKUPS: "{{ $logMaxBackups }}"
+  LOG_MAX_AGE: "{{ $logMaxAge }}"
+  LOG_COMPRESS: "{{ $logCompress }}"
+  LOG_LEVEL: "{{ $logLevel }}"

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -10,7 +10,7 @@
 {{- $dbPoolMaxConnLifetime := .Values.db.poolMaxConnLifetime | required "A valid .db.poolMaxConnLifetime is required!" -}}
 {{- $dbPoolMaxConnIdleTime := .Values.db.poolMaxConnIdleTime | required "A valid .db.poolMaxConnIdleTime is required!" -}}
 {{- $yhsServerAddr := .Values.yhsServerAddr | required "A valid .yhsServerAddr is required!" -}}
-{{- $logJSONFormat := .Values.log.useJSONFormat | required "A valid .log.useJSONFormat is required!" -}}
+{{- $logJSONFormat := .Values.log.jsonFormat | required "A valid .log.useJSONFormat is required!" -}}
 {{- $logLevel := .Values.log.level | required "A valid .log.level is required!" -}}
 
 
@@ -37,5 +37,5 @@ data:
   YHS_DB_POOL_MAX_CONN_LIFETIME: "{{ $dbPoolMaxConnLifetime }}"
   YHS_DB_POOL_MAX_CONN_IDLE_TIME: "{{ $dbPoolMaxConnIdleTime }}"
   YHS_YHS_SERVER_ADDR: "{{ $yhsServerAddr }}"
-  YHS_LOG_USE_JSON_FORMAT: "{{ $logJSONFormat }}"
+  YHS_LOG_JSON_FORMAT: "{{ $logJSONFormat }}"
   YHS_LOG_LEVEL: "{{ $logLevel }}"

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -10,11 +10,7 @@
 {{- $dbPoolMaxConnLifetime := .Values.db.poolMaxConnLifetime | required "A valid .db.poolMaxConnLifetime is required!" -}}
 {{- $dbPoolMaxConnIdleTime := .Values.db.poolMaxConnIdleTime | required "A valid .db.poolMaxConnIdleTime is required!" -}}
 {{- $yhsServerAddr := .Values.yhsServerAddr | required "A valid .yhsServerAddr is required!" -}}
-{{- $logFilePath := .Values.log.filePath | required "A valid .log.filePath is required!" -}}
-{{- $logMaxSize := .Values.log.maxSize | required "A valid .log.maxSize is required!" -}}
-{{- $logMaxBackups := .Values.log.maxBackups | required "A valid .log.maxBackups is required!" -}}
-{{- $logMaxAge := .Values.log.maxAge | required "A valid .log.maxAge is required!" -}}
-{{- $logCompress := .Values.log.compress | required "A valid .log.compress is required!" -}}
+{{- $logProduction := .Values.log.production | required "A valid .log.production is required!" -}}
 {{- $logLevel := .Values.log.level | required "A valid .log.level is required!" -}}
 
 
@@ -41,9 +37,5 @@ data:
   YHS_DB_POOL_MAX_CONN_LIFETIME: "{{ $dbPoolMaxConnLifetime }}"
   YHS_DB_POOL_MAX_CONN_IDLE_TIME: "{{ $dbPoolMaxConnIdleTime }}"
   YHS_YHS_SERVER_ADDR: "{{ $yhsServerAddr }}"
-  LOG_FILE_PATH: "{{ $logFilePath }}"
-  LOG_MAX_SIZE: "{{ $logMaxSize }}"
-  LOG_MAX_BACKUPS: "{{ $logMaxBackups }}"
-  LOG_MAX_AGE: "{{ $logMaxAge }}"
-  LOG_COMPRESS: "{{ $logCompress }}"
-  LOG_LEVEL: "{{ $logLevel }}"
+  YHS_LOG_PRODUCTION: "{{ $logProduction }}"
+  YHS_LOG_LEVEL: "{{ $logLevel }}"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -56,15 +56,7 @@ yunikorn:
   protocol: "http"
 
 log:
-    # -- Log file path
-    filePath: "yhs.log"
-    # -- Maximum log file size in megabytes
-    maxSize: 5
-    # -- Maximum number of log file backups
-    maxBackups: 10
-    # -- Maximum age of log files in days
-    maxAge: 30
-    # -- Compress log files
-    compress: true
+    # -- Output type of the log, if true, log will be output in json format
+    production: true
     # -- Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL
     level: "INFO"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -57,6 +57,6 @@ yunikorn:
 
 log:
     # -- Output type of the log, if true, log will be output in json format
-    production: true
+    useJSONFormat: true
     # -- Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL
     level: "INFO"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -57,6 +57,6 @@ yunikorn:
 
 log:
     # -- Output type of the log, if true, log will be output in json format
-    useJSONFormat: true
+    jsonFormat: true
     # -- Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL
     level: "INFO"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -54,3 +54,17 @@ yunikorn:
   port: ""
   # -- Yunikorn scheduler protocol
   protocol: "http"
+
+log:
+    # -- Log file path
+    filePath: "yhs.log"
+    # -- Maximum log file size in megabytes
+    maxSize: 5
+    # -- Maximum number of log file backups
+    maxBackups: 10
+    # -- Maximum age of log files in days
+    maxAge: 30
+    # -- Compress log files
+    compress: true
+    # -- Log level, one of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL
+    level: "INFO"

--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	// configure the logger
 	log.InitLogger(log.LogConfig{
-		JsonFormat: k.Bool("log.json_format"),
+		JSONFormat: k.Bool("log.json_format"),
 		LogLevel:   k.String("log.level"),
 	})
 

--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -12,12 +12,13 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
-	koanf "github.com/knadh/koanf/v2"
+	"github.com/knadh/koanf/v2"
 
 	"github.com/G-Research/yunikorn-history-server/internal/config"
 	"github.com/G-Research/yunikorn-history-server/internal/repository"
 	"github.com/G-Research/yunikorn-history-server/internal/webservice"
 	"github.com/G-Research/yunikorn-history-server/internal/ykclient"
+	"github.com/G-Research/yunikorn-history-server/log"
 )
 
 var (
@@ -70,6 +71,16 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	// configure the logger
+	log.InitLogger(log.LogConfig{
+		LogFilePath: k.String("log.log_file_path"),
+		MaxSize:     k.Int("log.max_size"),
+		MaxBackups:  k.Int("log.max_backups"),
+		MaxAge:      k.Int("log.max_age"), // days
+		Compress:    k.Bool("log.compress"),
+		LogLevel:    k.String("log.log_level"),
+	})
 
 	httpProto = k.String("yunikorn.protocol")
 	ykHost = k.String("yunikorn.host")

--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -74,12 +74,8 @@ func main() {
 
 	// configure the logger
 	log.InitLogger(log.LogConfig{
-		LogFilePath: k.String("log.file_path"),
-		MaxSize:     k.Int("log.max_size"),
-		MaxBackups:  k.Int("log.max_backups"),
-		MaxAge:      k.Int("log.max_age"), // days
-		Compress:    k.Bool("log.compress"),
-		LogLevel:    k.String("log.level"),
+		IsProduction: k.Bool("log.production"),
+		LogLevel:     k.String("log.level"),
 	})
 
 	httpProto = k.String("yunikorn.protocol")

--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -74,8 +74,8 @@ func main() {
 
 	// configure the logger
 	log.InitLogger(log.LogConfig{
-		UseJSONFormat: k.Bool("log.use_json_format"),
-		LogLevel:      k.String("log.level"),
+		JsonFormat: k.Bool("log.json_format"),
+		LogLevel:   k.String("log.level"),
 	})
 
 	httpProto = k.String("yunikorn.protocol")

--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -74,8 +74,8 @@ func main() {
 
 	// configure the logger
 	log.InitLogger(log.LogConfig{
-		IsProduction: k.Bool("log.production"),
-		LogLevel:     k.String("log.level"),
+		UseJSONFormat: k.Bool("log.use_json_format"),
+		LogLevel:      k.String("log.level"),
 	})
 
 	httpProto = k.String("yunikorn.protocol")

--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -74,12 +74,12 @@ func main() {
 
 	// configure the logger
 	log.InitLogger(log.LogConfig{
-		LogFilePath: k.String("log.log_file_path"),
+		LogFilePath: k.String("log.file_path"),
 		MaxSize:     k.Int("log.max_size"),
 		MaxBackups:  k.Int("log.max_backups"),
 		MaxAge:      k.Int("log.max_age"), // days
 		Compress:    k.Bool("log.compress"),
-		LogLevel:    k.String("log.log_level"),
+		LogLevel:    k.String("log.level"),
 	})
 
 	httpProto = k.String("yunikorn.protocol")

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.26.0
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/log/logger.go
+++ b/log/logger.go
@@ -10,7 +10,7 @@ import (
 )
 
 type LogConfig struct {
-	JsonFormat bool
+	JSONFormat bool
 	LogLevel   string
 }
 
@@ -30,7 +30,7 @@ func InitLogger(config LogConfig) {
 
 		var encoder zapcore.Encoder
 		encoder = zapcore.NewConsoleEncoder(cfg)
-		if config.JsonFormat {
+		if config.JSONFormat {
 			encoder = zapcore.NewJSONEncoder(cfg)
 		}
 		core := zapcore.NewCore(encoder, stdout, parseLevel(config.LogLevel))

--- a/log/logger.go
+++ b/log/logger.go
@@ -10,8 +10,8 @@ import (
 )
 
 type LogConfig struct {
-	UseJSONFormat bool
-	LogLevel      string
+	JsonFormat bool
+	LogLevel   string
 }
 
 var (
@@ -30,7 +30,7 @@ func InitLogger(config LogConfig) {
 
 		var encoder zapcore.Encoder
 		encoder = zapcore.NewConsoleEncoder(cfg)
-		if config.UseJSONFormat {
+		if config.JsonFormat {
 			encoder = zapcore.NewJSONEncoder(cfg)
 		}
 		core := zapcore.NewCore(encoder, stdout, parseLevel(config.LogLevel))

--- a/log/logger.go
+++ b/log/logger.go
@@ -10,8 +10,8 @@ import (
 )
 
 type LogConfig struct {
-	IsProduction bool
-	LogLevel     string
+	UseJSONFormat bool
+	LogLevel      string
 }
 
 var (
@@ -23,20 +23,16 @@ func InitLogger(config LogConfig) {
 	once.Do(func() {
 		stdout := zapcore.AddSync(os.Stdout)
 
-		productionCfg := zap.NewProductionEncoderConfig()
-		productionCfg.TimeKey = "timestamp"
-		productionCfg.EncodeTime = zapcore.ISO8601TimeEncoder
-
-		developmentCfg := zap.NewDevelopmentEncoderConfig()
-		developmentCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		cfg := zap.NewProductionEncoderConfig()
+		cfg.TimeKey = "timestamp"
+		cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+		cfg.EncodeLevel = zapcore.CapitalLevelEncoder
 
 		var encoder zapcore.Encoder
-		if config.IsProduction {
-			encoder = zapcore.NewJSONEncoder(productionCfg)
-		} else {
-			encoder = zapcore.NewConsoleEncoder(developmentCfg)
+		encoder = zapcore.NewConsoleEncoder(cfg)
+		if config.UseJSONFormat {
+			encoder = zapcore.NewJSONEncoder(cfg)
 		}
-
 		core := zapcore.NewCore(encoder, stdout, parseLevel(config.LogLevel))
 
 		Logger = zap.New(core)

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,38 +2,37 @@ package log
 
 import (
 	"os"
+	"strconv"
 	"sync"
-
-	"gopkg.in/natefinch/lumberjack.v2"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-// TODO: implement a mechanism to load this values from configuration
-const (
-	logFilePath = "yhs.log"
-	maxSize     = 5
-	maxBackups  = 10
-	maxAge      = 14
-	compress    = true
-	logLevel    = zap.InfoLevel
-)
+type LogConfig struct {
+	LogFilePath string
+	MaxSize     int
+	MaxBackups  int
+	MaxAge      int
+	Compress    bool
+	LogLevel    string
+}
 
 var (
 	once   sync.Once
 	Logger *zap.Logger
 )
 
-func init() {
+func InitLogger(config LogConfig) {
 	once.Do(func() {
 		stdout := zapcore.AddSync(os.Stdout)
 		file := zapcore.AddSync(&lumberjack.Logger{
-			Filename:   logFilePath,
-			MaxSize:    maxSize,
-			MaxBackups: maxBackups,
-			MaxAge:     maxAge,
-			Compress:   compress,
+			Filename:   config.LogFilePath,
+			MaxSize:    config.MaxSize,
+			MaxBackups: config.MaxBackups,
+			MaxAge:     config.MaxAge,
+			Compress:   config.Compress,
 		})
 
 		productionCfg := zap.NewProductionEncoderConfig()
@@ -47,10 +46,38 @@ func init() {
 		fileEncoder := zapcore.NewJSONEncoder(productionCfg)
 
 		core := zapcore.NewTee(
-			zapcore.NewCore(consoleEncoder, stdout, logLevel),
-			zapcore.NewCore(fileEncoder, file, logLevel),
+			zapcore.NewCore(consoleEncoder, stdout, parseLevel(config.LogLevel)),
+			zapcore.NewCore(fileEncoder, file, parseLevel(config.LogLevel)),
 		)
 
 		Logger = zap.New(core)
 	})
+}
+
+// parseLevel parses a textual (or numeric) log level into a `zapcore.Level` instance.
+// Both numeric (-1 <= level <= 5)
+// and textual (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL) are supported.
+// Ref: https://github.com/apache/yunikorn-core/blob/a786feb5761be28e802d08976d224c40639cd86b/pkg/log/logger.go#L301
+func parseLevel(level string) *zapcore.Level {
+	// parse text
+	zapLevel, err := zapcore.ParseLevel(level)
+	if err == nil {
+		return &zapLevel
+	}
+
+	// parse numeric
+	levelNum, err := strconv.ParseInt(level, 10, 31)
+	if err == nil {
+		zapLevel = zapcore.Level(levelNum)
+		if zapLevel < zapcore.DebugLevel {
+			zapLevel = zapcore.DebugLevel
+		}
+		if zapLevel >= zapcore.InvalidLevel {
+			zapLevel = zapcore.InvalidLevel - 1
+		}
+		return &zapLevel
+	}
+
+	// parse failed
+	return nil
 }

--- a/yhs.yml
+++ b/yhs.yml
@@ -17,9 +17,9 @@ yhs:
   server_addr: ":8989"
 
 log:
-  log_file_path: "yhs.log"
+  file_path: "yhs.log"
   max_size: 5
   max_backups: 10
   max_age: 30
   compress: true
-  log_level: "INFO"
+  level: "INFO"

--- a/yhs.yml
+++ b/yhs.yml
@@ -18,4 +18,4 @@ yhs:
 
 log:
   level: "INFO"
-  production: false
+  use_json_format: true

--- a/yhs.yml
+++ b/yhs.yml
@@ -17,9 +17,5 @@ yhs:
   server_addr: ":8989"
 
 log:
-  file_path: "yhs.log"
-  max_size: 5
-  max_backups: 10
-  max_age: 30
-  compress: true
   level: "INFO"
+  production: false

--- a/yhs.yml
+++ b/yhs.yml
@@ -18,4 +18,4 @@ yhs:
 
 log:
   level: "INFO"
-  use_json_format: true
+  json_format: false

--- a/yhs.yml
+++ b/yhs.yml
@@ -15,3 +15,11 @@ db:
   pool_max_conn_idle_time: 120s
 yhs:
   server_addr: ":8989"
+
+log:
+  log_file_path: "yhs.log"
+  max_size: 5
+  max_backups: 10
+  max_age: 30
+  compress: true
+  log_level: "INFO"


### PR DESCRIPTION
closes #48 

Changes:

- [x] Reading logging configuration for ENV/config file
- [x] Support for Log level strings `DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL`
- [x] Some housekeeping 