### PR TITLE
Implement test to verify queue creation

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/G-Research/yunikorn-history-server/internal/webservice"
 	"github.com/G-Research/yunikorn-history-server/internal/yunikorn/model"
 	"github.com/G-Research/yunikorn-history-server/test/k8s"
+	"github.com/G-Research/yunikorn-history-server/test/util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
@@ -100,7 +101,7 @@ func TestYunikornQueueCreation_E2E(t *testing.T) {
 		t.Skip("skipping e2e test in short mode")
 	}
 	ns := "yunikorn"
-	queueName := "tenant" // a random name
+	queueName := util.GenerateRandomAlphanum(t, 8) + "test-queue"
 	configMap := testQueueConfigMap(queueName)
 
 	ctx, cancel = context.WithCancel(context.Background())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,8 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/G-Research/yunikorn-history-server/cmd/yunikorn-history-server/commands"
 	"github.com/G-Research/yunikorn-history-server/internal/health"
+	"github.com/G-Research/yunikorn-history-server/internal/webservice"
 	"github.com/G-Research/yunikorn-history-server/internal/yunikorn/model"
 	"github.com/G-Research/yunikorn-history-server/test/k8s"
 	"github.com/google/go-cmp/cmp"
@@ -16,31 +22,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
-	"net/http"
-	"os"
-	"testing"
-	"time"
 )
 
 const (
 	testNamespacePrefix = "yunikorn-e2e-"
+	serverURL           = "http://localhost:8989"
 )
+
+var ctx context.Context
+var cancel context.CancelFunc
+
+func TestMain(m *testing.M) {
+	// Setup
+	ctx, cancel = context.WithCancel(context.Background())
+	go runApp(ctx)
+
+	// Run the tests
+	code := m.Run()
+
+	// Teardown
+	cancel()
+	os.Exit(code)
+}
 
 func TestYunikornEventStream_E2E(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test in short mode")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	ns := createTestNamespace(ctx, t, k8s.GetTestK8sClient(t))
 	t.Cleanup(func() {
 		deleteTestNamespace(context.Background(), t, k8s.GetTestK8sClient(t), ns)
 	})
-
-	serverURL := "http://localhost:8989"
-	go runApp(ctx)
 
 	assert.Eventually(t, func() bool {
 		healthy, err := getReadinessStatus(serverURL)
@@ -77,6 +93,69 @@ func TestYunikornEventStream_E2E(t *testing.T) {
 		diff := cmp.Diff(expectedCounts, counts)
 		return diff == ""
 	}, 100*time.Second, 5*time.Second)
+}
+
+func TestYunikornQueueCreation_E2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+	ns := "yunikorn"
+	queueName := "tenant" // a random name
+	configMap := testQueueConfigMap(queueName)
+
+	ctx, cancel = context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Cleanup(func() {
+		k8sClient := k8s.GetTestK8sClient(t)
+		err := k8sClient.CoreV1().ConfigMaps(ns).Delete(ctx, configMap.Name, metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("error deleting configmap: %v", err)
+		}
+	})
+
+	assert.Eventually(t, func() bool {
+		healthy, err := getReadinessStatus(serverURL)
+		return healthy && err == nil
+	}, 10*time.Second, 500*time.Millisecond)
+
+	// sleep for 2 seconds just in case so all goroutines are ready
+	time.Sleep(2 * time.Second)
+
+	k8sClient := k8s.GetTestK8sClient(t)
+
+	// create the configmap which has the queue definition
+	_, err := k8sClient.CoreV1().ConfigMaps(ns).Create(ctx, configMap, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating test queue: %v", err)
+	}
+
+	expectedCount := 5
+	assert.Eventually(t, func() bool {
+		counts, err := getEventStatistics(serverURL)
+		if err != nil {
+			return false
+		}
+		actualCount, ok := counts["QUEUE-ADD"]
+		return ok && actualCount == expectedCount
+	}, 100*time.Second, 5*time.Second)
+
+	assert.Eventually(t, func() bool {
+		queuesResponse, err := getQueues(serverURL)
+		if err != nil {
+			return false
+		}
+		for _, queue := range queuesResponse.Queues {
+			if queue.QueueName == "root" {
+				for _, childQueue := range queue.Children {
+					if childQueue.QueueName == "root."+queueName {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}, 400*time.Second, 5*time.Second)
 }
 
 // createTestNamespace creates a test namespace for the e2e test and returns the name of the namespace.
@@ -117,8 +196,16 @@ func getEventStatistics(serverURL string) (model.EventTypeCounts, error) {
 	if err := httpGet(url, &counts); err != nil {
 		return nil, err
 	}
-
 	return counts, nil
+}
+
+func getQueues(serverURL string) (webservice.QueuesResponse, error) {
+	var queues webservice.QueuesResponse
+	url := fmt.Sprintf("%s/ws/v1/partition/default/queues", serverURL)
+	if err := httpGet(url, &queues); err != nil {
+		return webservice.QueuesResponse{}, err
+	}
+	return queues, nil
 }
 
 // httpGet performs an HTTP GET request and decodes the response into the provided out parameter.
@@ -184,6 +271,24 @@ func testJob() *batchv1.Job {
 					},
 				},
 			},
+		},
+	}
+}
+
+func testQueueConfigMap(queue string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "yunikorn-configs",
+		},
+		Data: map[string]string{
+			"queues.yaml": fmt.Sprintf(`
+partitions:
+  - name: default
+    queues:
+      - name: root
+        queues:
+          - name: %s
+`, queue),
 		},
 	}
 }


### PR DESCRIPTION
Closes #80 

Implement an end-to-end test to verify that YHS can observe queue creation events in the `yunikorn` scheduler. Also, verify that the event is saved and the data is visible in the web service.

**Definition of Done (DoD)**

- [x] Apply the config map that contains the queue definition. Reference: [partition-and-queue-configuration](https://yunikorn.apache.org/docs/1.5.0/user_guide/use_cases/#partition-and-queue-configuration).
- [x] Verify the `QUEUE-ADD` event counts.
- [x] Verify that the newly created queue is returned by the web service at the `/ws/v1/partition/:partition/queues` endpoint.

**Refactor**

- [x] Use `TestMain` to run the application once for all the tests.

**Notes**

Processing and returning the newly created queues by the web service takes considerable time. Therefore, the timeout is set to `400` seconds, making the process quite slow.