### PR TITLE
Publish chart to G-Research/charts repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,3 +70,12 @@ jobs:
             $(printf -- "--tag ${{ vars.DOCKER_REPO }}:%s " ${tags[@]}) \
             $(printf "${{ vars.DOCKER_REPO }}@%s " ${digests[@]})
           echo "::endgroup::"
+
+  # Secrets are placed under `invoke-push` environment
+  invoke-chart-push:
+    name: Invoke Chart push
+    needs: docker-release
+    uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Checks:
- Create GitHub app required for this process and pass the fingerprint of the created app via comment on this https://github.com/G-Research/charts/pull/132
  - [x] App created, we have fingerprint too `wrNW9GyqMpq4pv1EgXrgwYPweqsHJo2hRzqOMiBYjS8=`
- Create the environment `invoke-push` and add following secrets from created app
  - [x] `APP_ID` and `APP_PRIVATE_KEY` are created under `invoke-push` environment
 

Goal of this PR is to use official process of publishing charts to G-Research repo https://g-research.github.io/charts/