### PR TITLE
Integration test fixes

### DIFF
--- a/internal/health/health_int_test.go
+++ b/internal/health/health_int_test.go
@@ -44,8 +44,7 @@ func TestService_Readiness_Integration(t *testing.T) {
 		status := service.Readiness(context.Background())
 		assert.False(t, status.Healthy)
 		assert.Equal(t, 2, len(status.ComponentStatuses))
-		expectedError := "Get \"http://invalid-host:2212/ws/v1/scheduler/healthcheck\": dial tcp: lookup invalid-host: no such host"
-		assertStatus(t, status.ComponentStatuses, "yunikorn", false, expectedError)
+		assertStatus(t, status.ComponentStatuses, "yunikorn", false)
 		assert.Equal(t, now, status.StartedAt)
 		assert.Equal(t, version, status.Version)
 	})
@@ -75,11 +74,13 @@ func TestService_Readiness_Integration(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, statuses []*ComponentStatus, identifier string, expectedHealthy bool, expectedError string) {
+func assertStatus(t *testing.T, statuses []*ComponentStatus, identifier string, expectedHealthy bool) {
+	expectedErrorPrefix := `Get "http://invalid-host:2212/ws/v1/scheduler/healthcheck": dial tcp: lookup invalid-host`
+
 	for _, status := range statuses {
 		if status.Identifier == identifier {
 			assert.Equal(t, expectedHealthy, status.Healthy)
-			assert.Equal(t, expectedError, status.Error)
+			assert.Contains(t, status.Error, expectedErrorPrefix)
 			return
 		}
 	}

--- a/internal/health/health_int_test.go
+++ b/internal/health/health_int_test.go
@@ -42,9 +42,10 @@ func TestService_Readiness_Integration(t *testing.T) {
 			components: components,
 		}
 		status := service.Readiness(context.Background())
+		expectErrorPrefix := `Get "http://invalid-host:2212/ws/v1/scheduler/healthcheck": dial tcp: lookup invalid-host`
 		assert.False(t, status.Healthy)
 		assert.Equal(t, 2, len(status.ComponentStatuses))
-		assertStatus(t, status.ComponentStatuses, "yunikorn", false)
+		assertStatus(t, status.ComponentStatuses, "yunikorn", false, expectErrorPrefix)
 		assert.Equal(t, now, status.StartedAt)
 		assert.Equal(t, version, status.Version)
 	})
@@ -74,9 +75,7 @@ func TestService_Readiness_Integration(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, statuses []*ComponentStatus, identifier string, expectedHealthy bool) {
-	expectedErrorPrefix := `Get "http://invalid-host:2212/ws/v1/scheduler/healthcheck": dial tcp: lookup invalid-host`
-
+func assertStatus(t *testing.T, statuses []*ComponentStatus, identifier string, expectedHealthy bool, expectedErrorPrefix string) {
 	for _, status := range statuses {
 		if status.Identifier == identifier {
 			assert.Equal(t, expectedHealthy, status.Healthy)

--- a/internal/yunikorn/sync_int_test.go
+++ b/internal/yunikorn/sync_int_test.go
@@ -70,16 +70,8 @@ func TestClient_sync_Integration(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		partitions, err := repo.GetAllPartitions(ctx)
 		if err != nil {
-			t.Fatalf("error getting partitions: %v", err)
+			t.Logf("error getting partitions: %v", err)
 		}
 		return len(partitions) > 0
-	}, 10*time.Second, 250*time.Millisecond)
-
-	assert.Eventually(t, func() bool {
-		history, err := repo.GetApplicationsHistory(ctx)
-		if err != nil {
-			t.Fatalf("error getting applications history: %v", err)
-		}
-		return len(history) > 0
 	}, 10*time.Second, 250*time.Millisecond)
 }


### PR DESCRIPTION
Remove application history check - this is inherently a flaky test, due to Yunikorn having very variable processing time for application history data, so we cannot rely on it without having a very long timeout value.

Fix check for expected error message when we specify a bad health endpoint URL - Linux gives a different trailing message after the "lookup invalid-host" substring. This now passes on both MacOS and Linux systems.

Make check for getting parititons just log the error, and not be fatal.

Fixes https://github.com/G-Research/yunikorn-history-server/issues/97