### PR TITLE
publish helm chart only on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
   invoke-chart-push:
     name: Invoke Chart push
     needs: docker-release
+    if: startsWith(github.ref, 'refs/tags/v')
     uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
     secrets:
       APP_ID: ${{ secrets.APP_ID }}


### PR DESCRIPTION
As discussed internally, proposed way to publish helm chart should be only when pushing tags starting with `refs/tags/v`