### PR TITLE
[YHS-165] upadte build and add command in chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ endif
 
 .PHONY: kind-load-image
 kind-load-image: docker-build-amd64 ## inject the local docker image into the kind cluster.
-	kind load docker-image $(IMAGE_TAG) --name $(KIND_CLUSTER)
+	kind load docker-image $(IMAGE_TAG) --name $(CLUSTER_NAME)
 
 .PHONY: install-dependencies
 install-dependencies: helm-repos install-and-patch-yunikorn helm-install-postgres wait-for-dependencies ## install dependencies.

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ web-build: ng ## build the web components.
 .PHONY: build
 build: bin/app ## build the yunikorn-history-server binary for current OS and architecture.
 	echo "Building yunikorn-history-server binary for $(OS)/$(ARCH)"
-	GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -o $(LOCALBIN_APP)/yunikorn-history-server 										\
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -o $(LOCALBIN_APP)/yunikorn-history-server 										\
 		-ldflags "-X github.com/G-Research/yunikorn-history-server/cmd/yunikorn-history-server/info.Version=$(GIT_TAG) 		\
 				  -X github.com/G-Research/yunikorn-history-server/cmd/yunikorn-history-server/info.Commit=$(GIT_COMMIT) 	\
 				  -X github.com/G-Research/yunikorn-history-server/cmd/yunikorn-history-server/info.BuildTime=$(BUILD_TIME)" \

--- a/charts/yunikorn-history-server/templates/deployment.yaml
+++ b/charts/yunikorn-history-server/templates/deployment.yaml
@@ -39,7 +39,6 @@ spec:
         - name: "yunikorn-history-server"
           image: "{{ include "yunikorn-history-server.image" . }}"
           imagePullPolicy: "{{ $imagePullPolicy }}"
-          command: ["/app/yunikorn-history-server"]
           args:
             - "--config"
             - "/app/config/config.yaml"

--- a/charts/yunikorn-history-server/templates/deployment.yaml
+++ b/charts/yunikorn-history-server/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - name: "yunikorn-history-server"
           image: "{{ include "yunikorn-history-server.image" . }}"
           imagePullPolicy: "{{ $imagePullPolicy }}"
+          command: ["/app/yunikorn-history-server"]
           args:
             - "--config"
             - "/app/config/config.yaml"


### PR DESCRIPTION
# What is PR?
This PR fixs the failure by adopts CGO option when compiling and adds the command to the chart/template/deployment.yml. 

# Related issues
#165 

# How to validate?
```
# prepare a kind cluster
make kind-all
# load custom image to the kind
make kind-load-image
sed -i 's/tag: .*/tag: "<YOUR IMAGE TAG>"/g' charts/yunikorn-history-server/values.yaml
helm install yhs chart -n yunikorn
```
# Screenshots
![image](https://github.com/user-attachments/assets/51cd8db0-88c8-4b1c-b541-3d84d4e3c008)
![image](https://github.com/user-attachments/assets/4d89e95f-bd80-4032-a89b-11a1a75e3376)