### PR TITLE
Reorder CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,6 @@ jobs:
   all-required-checks-done:
     name: All required checks done
     needs:
-      - go-lint
-      - go-unit-tests
-      - go-integration-tests
       - build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
   build:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Build (${{ matrix.os }}/${{ matrix.arch }})
+    needs:
+      - go-lint
+      - go-unit-tests
+      - go-integration-tests
     strategy:
       matrix:
         os: [ linux ]


### PR DESCRIPTION
This PR reorders jobs in the main CI so that they execute in a serial fashion. First tests, then build, and then the rest.

Fixes: https://github.com/G-Research/yunikorn-history-server/issues/172