### PR TITLE
Implement SPA handler to return ui on root path

### DIFF
--- a/internal/webservice/routes.go
+++ b/internal/webservice/routes.go
@@ -3,6 +3,8 @@ package webservice
 import (
 	"context"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
@@ -13,7 +15,6 @@ import (
 
 const (
 	// routes
-
 	routeClusters                 = "/ws/v1/clusters"
 	routePartitions               = "/ws/v1/partitions"
 	routeQueuesPerPartition       = "/ws/v1/partition/:partition_name/queues"
@@ -26,18 +27,16 @@ const (
 	routeEventStatistics          = "/ws/v1/event-statistics"
 	routeHealthLiveness           = "/ws/v1/health/liveness"
 	routeHealthReadiness          = "/ws/v1/health/readiness"
-	routeWeb                      = "/web"
-	// params
 
+	// params
 	paramsPartitionName = "partition_name"
 	paramsQueueName     = "queue_name"
 )
 
 func (ws *WebService) init(ctx context.Context) {
 	router := httprouter.New()
+	router.NotFound = http.HandlerFunc(ws.serveSPA)
 
-	fs := http.Dir(ws.assetsDir)
-	router.Handler(http.MethodGet, routeWeb+"/*filepath", http.StripPrefix(routeWeb, http.FileServer(fs)))
 	router.Handle(http.MethodGet, routePartitions, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		enrichRequestContext(ctx, r)
 		ws.getPartitions(w, r, p)
@@ -191,4 +190,20 @@ func (ws *WebService) LivenessHealthcheck(w http.ResponseWriter, r *http.Request
 
 func (ws *WebService) ReadinessHealthcheck(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, ws.healthService.Readiness(r.Context()))
+}
+
+func (ws *WebService) serveSPA(w http.ResponseWriter, r *http.Request) {
+	path := filepath.Join(ws.assetsDir, r.URL.Path)
+
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) || fi.IsDir() {
+		http.ServeFile(w, r, filepath.Join(ws.assetsDir, "index.html"))
+	}
+
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	http.FileServer(http.Dir(ws.assetsDir)).ServeHTTP(w, r)
 }

--- a/internal/webservice/routes.go
+++ b/internal/webservice/routes.go
@@ -194,10 +194,10 @@ func (ws *WebService) ReadinessHealthcheck(w http.ResponseWriter, r *http.Reques
 
 func (ws *WebService) serveSPA(w http.ResponseWriter, r *http.Request) {
 	path := filepath.Join(ws.assetsDir, r.URL.Path)
-
 	fi, err := os.Stat(path)
 	if os.IsNotExist(err) || fi.IsDir() {
 		http.ServeFile(w, r, filepath.Join(ws.assetsDir, "index.html"))
+		return
 	}
 
 	if err != nil {

--- a/internal/webservice/routes_test.go
+++ b/internal/webservice/routes_test.go
@@ -1,0 +1,58 @@
+package webservice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebServiceServeSPA(t *testing.T) {
+	ws := &WebService{
+		assetsDir: "testdir",
+	}
+
+	tt := map[string]struct {
+		path            string
+		wantFile        string
+		wantContentType string
+	}{
+		"root path": {
+			path:            "/",
+			wantFile:        "testdir/index.html",
+			wantContentType: "text/html; charset=utf-8",
+		},
+		"js file": {
+			path:            "/js/app.js",
+			wantFile:        "testdir/js/app.js",
+			wantContentType: "text/javascript",
+		},
+		"file not found": {
+			path:            "/notfound",
+			wantFile:        "testdir/index.html",
+			wantContentType: "text/html; charset=utf-8",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			ws.serveSPA(rec, req)
+
+			f, err := os.Open(tc.wantFile)
+			require.NoError(t, err)
+			defer f.Close()
+
+			wantContent, err := os.ReadFile(tc.wantFile)
+			require.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, string(wantContent), rec.Body.String())
+			assert.Contains(t, rec.Header().Get("Content-Type"), tc.wantContentType)
+		})
+	}
+}

--- a/internal/webservice/testdir/index.html
+++ b/internal/webservice/testdir/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>SPA</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="js/app.js"></script>
+    <noscript>
+      <strong>We're sorry but SPA doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    </noscript>
+  </body>
+</html>

--- a/internal/webservice/testdir/js/app.js
+++ b/internal/webservice/testdir/js/app.js
@@ -1,0 +1,1 @@
+console.log("Hello World");


### PR DESCRIPTION
SPA handler returns index.html if the file requested is not present, so it can leave routing to the UI framework.

Fixes #59