### PR TITLE
Add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ env CLUSTER_MGR=minikube make tests
 ```
 should all succeed without error.
 
+## Security
+
+Please see our [security policy](https://github.com/G-Research/yunikorn-history-server/blob/main/SECURITY.md) for details on reporting security vulnerabilities.
+
 ## License
 
 See the [LICENSE](LICENSE) file for licensing information.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security and Coordinated Vulnerability Disclosure Policy
+
+This project appreciates and encourages coordinated disclosure of security vulnerabilities. We prefer that you use the GitHub reporting mechanism to privately report vulnerabilities. Under the main repository's security tab, click "Report a vulnerability" to open the advisory form.
+
+If you are unable to report it via GitHub, have received no response after repeated attempts, or have other security related questions, please contact security @ gr-oss.io and mention this project in the subject line.


### PR DESCRIPTION
Add a security policy file and a corresponding section to README.

A security policy (typically a SECURITY.md file) can give users information about what constitutes a vulnerability and how to report one securely so that information about a bug is not publicly visible.