### PR TITLE
Remove faulty integration test.

### DIFF
--- a/internal/yunikorn/sync_int_test.go
+++ b/internal/yunikorn/sync_int_test.go
@@ -58,6 +58,7 @@ func TestClient_sync_Integration(t *testing.T) {
 		return len(partitions) > 0
 	}, 10*time.Second, 250*time.Millisecond)
 
+	// cleanup after test
 	t.Cleanup(func() {
 		s.workqueue.Shutdown()
 		cleanupDB()


### PR DESCRIPTION
We are moving away form `sync` loop. Hence we do not need this test. 

closes #280 