### PR TITLE
GROSS-1358: SHA-pin GitHub Actions

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - id: setup-go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version-file: "go.mod"
         check-latest: true
@@ -20,7 +20,7 @@ runs:
     - id: cache-info
       shell: bash
       run: echo path=$(go env GOCACHE) >> $GITHUB_OUTPUT
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache-info.outputs.path }}
         key: ${{ inputs.cache-prefix }}-go-${{ steps.setup-go.outputs.go-version }}-mod-${{ hashFiles('go.sum') }}

--- a/.github/workflows/check-required.yml
+++ b/.github/workflows/check-required.yml
@@ -27,11 +27,11 @@ jobs:
     steps:
       - name: Generate an app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: G-Research/common-actions/check-required@main
+      - uses: G-Research/common-actions/check-required@b6771a9cc351238f2964b3a2801aa655d72afcc4 # main
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
         id: setup-go
@@ -29,7 +29,7 @@ jobs:
           echo make-hash=$(make -n install-tools | sha256sum | cut -d' ' -f1) >> $GITHUB_OUTPUT
 
       - name: Setup tools cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: tools-cache
         with:
           path: ${{ steps.tools-cache-info.outputs.path }}
@@ -64,7 +64,7 @@ jobs:
           echo path=${BASH_REMATCH[1]} >> $GITHUB_OUTPUT
 
       - name: Setup golangci-lint cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.golangci-lint-cache-info.outputs.path }}
           key: golangci-lint-${{ steps.golangci-lint-cache-info.outputs.version }}-go-${{ steps.setup-go.outputs.go-version }}-mod-${{ hashFiles('go.sum') }}
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -152,11 +152,11 @@ jobs:
           cache-prefix: build-${{ matrix.os }}-${{ matrix.arch }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Docker metadata
         id: docker-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: unicorn-history-server
           tags: |
@@ -173,7 +173,7 @@ jobs:
           DOCKER_METADATA: ${{ steps.docker-metadata.outputs.json }}
 
       - name: Upload Docker artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: unicorn-history-server-oci-images-${{ matrix.arch }}
           path: bin/docker/unicorn-history-server-oci-*.tar

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,7 +25,7 @@ jobs:
       has_pages: ${{ steps.has-pages.outputs.has_pages }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set 'has_pages' to output
         id: has-pages
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
           cache: yarn
@@ -42,11 +42,11 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
         if: github.ref == 'refs/heads/main' && steps.has-pages.outputs.has_pages == 'true'
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             website/build
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main' && steps.has-pages.outputs.has_pages == 'true'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./website/build
 
@@ -83,4 +83,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       # We need to checkout the repo in order to determine the latest tag.
       - name: Checkout
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-tags: 1
 
@@ -43,13 +43,13 @@ jobs:
           echo "tags=${tags[@]}" >> $GITHUB_OUTPUT
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: unicorn-history-server-oci-images-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -76,7 +76,7 @@ jobs:
     name: Invoke Chart push
     needs: docker-release
     if: startsWith(github.ref, 'refs/tags/v')
-    uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
+    uses: G-Research/charts/.github/workflows/invoke-push.yaml@da1730170639264eb7d32931bac437820c406951 # master
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Pin all GitHub Actions references to full commit SHAs (with trailing `# <version>` comments).

Ref: G-Research/gr-oss#1358

## Why

A mutable `@vN` / `@main` ref can be silently rewritten or compromised and is picked up immediately by every workflow run. Pinning to an immutable commit SHA closes that supply-chain risk; the trailing comment keeps the pin human-readable.

## Notes

- The local composite action `.github/actions/setup-go/action.yml` was pinned as well (`setup-go`, `cache`).
- First-party refs were pinned to their current branch SHA with a branch comment, per the existing convention used elsewhere in the org (e.g. ApiSurface): `G-Research/common-actions/check-required@<sha> # main` and `G-Research/charts/.github/workflows/invoke-push.yaml@<sha> # master`.
- Local references (`./.github/actions/setup-go`, `./.github/workflows/release.yml`) are left as-is (not pinnable).
- Dependabot already scans the `github-actions` ecosystem here, so no Dependabot change is needed.