### PR TITLE
Fix Docker build: pin pnpm to 9 for the web front-ends

### DIFF
--- a/build/unicorn-history-server/Dockerfile
+++ b/build/unicorn-history-server/Dockerfile
@@ -7,7 +7,7 @@ COPY web /build/src
 
 WORKDIR /build/src
 
-RUN npm install -g pnpm            && \
+RUN npm install -g pnpm@9          && \
     pnpm install                   && \
     pnpm run build:prod
 


### PR DESCRIPTION
## What

Pin the global pnpm install to **pnpm 9** in `build/unicorn-history-server/Dockerfile`.

## Why

The Docker build (`make docker-build`) fails while building the `yunikorn-web` front-end:

```
[ERR_PNPM_UNSUPPORTED_ENGINE] ... Expected version: 9  Got: 11.8.0
```

The Dockerfile runs `npm install -g pnpm`, which installs the **latest** pnpm (11). Both web projects declare `engines.pnpm: "9"`:

- the repo's own `web/` also sets `packageManager: pnpm@9.15.4`, so corepack already runs it with pnpm 9 (works today),
- the cloned `yunikorn-web` has **no `packageManager` field**, so it falls back to the global pnpm 11 and the engine check fails.

Pinning the global install to `pnpm@9` satisfies both front-ends.

## Change

```dockerfile
RUN npm install -g pnpm@9 && pnpm install && pnpm run build:prod
```

## Notes

- Environmental/build fix only; no application code changed.
